### PR TITLE
Add Ammo system

### DIFF
--- a/Assets/Imports/FPS/Scripts/Game/Shared/IceCreamInventoryManager.cs
+++ b/Assets/Imports/FPS/Scripts/Game/Shared/IceCreamInventoryManager.cs
@@ -1,42 +1,91 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using System;
 
+public class ScoopAmmoChangedEventArgs : EventArgs
+{
+    public FlavorType AmmoType { get; }
+    public int CurrentAmmoCount { get; }
+    public int MaxAmmoCount { get; }
+
+    public ScoopAmmoChangedEventArgs(FlavorType flavor, int current, int max)
+    {
+        AmmoType = flavor;
+        CurrentAmmoCount = current;
+        MaxAmmoCount = max;
+    }
+}
 public class IceCreamInventoryManager : MonoBehaviour
 {
     [SerializeField] private ProjectileBase[] m_ScoopProjectiles;
-    [SerializeField] private int m_CurrentScoopIndex = 0;
     [SerializeField] private FlavorType[] AllScoopTypes;
+    [SerializeField] private int MaxScoopAmount = 10;
 
     FlavorType m_ScoopType;
+    Dictionary<FlavorType, int> m_ScoopAmmoCounts;
 
     public FlavorType CurrentPlayerType => m_ScoopType;
+
+    public event EventHandler<ScoopAmmoChangedEventArgs> OnScoopAmmoChangedEvent;
+
+    public int CurrentAmmo
+    {
+        get => m_ScoopAmmoCounts[m_ScoopType];
+    }
 
     // Start is called before the first frame update
     void Start()
     {
-        m_ScoopType = AllScoopTypes[m_CurrentScoopIndex];
+        m_ScoopType = FlavorType.CHOCOLATE;
+        m_ScoopAmmoCounts = new Dictionary<FlavorType, int>();
+
+        foreach (var flavor in AllScoopTypes)
+        {
+            m_ScoopAmmoCounts[flavor] = MaxScoopAmount;
+        }
     }
 
     // Update is called once per frame
     void Update()
     {
-        if (Input.GetButtonDown("NextFlavor"))
+        if (Input.GetKeyDown(KeyCode.Alpha1))
         {
-            m_CurrentScoopIndex += 1;
-            if (m_CurrentScoopIndex > AllScoopTypes.Length - 1)
-            {
-                m_CurrentScoopIndex = 0;
-            }
-
-            m_ScoopType = AllScoopTypes[m_CurrentScoopIndex];
-
-            Debug.Log("Current Flavor is: " + m_ScoopType);
+            m_ScoopType = FlavorType.CHOCOLATE;
+        }
+        else if (Input.GetKeyDown(KeyCode.Alpha2))
+        {
+            m_ScoopType = FlavorType.VANILLA;
+        }
+        else if (Input.GetKeyDown(KeyCode.Alpha3))
+        {
+            m_ScoopType = FlavorType.BERRY;
+        }
+        else if (Input.GetKeyDown(KeyCode.Alpha4))
+        {
+            m_ScoopType = FlavorType.MINT;
         }
     }
 
     public ProjectileBase GetCurrentScoopType()
     {
-        return m_ScoopProjectiles[m_CurrentScoopIndex];
+        return m_ScoopProjectiles[(int)m_ScoopType];
+    }
+
+    public void UpdateAmmo()
+    {
+        m_ScoopAmmoCounts[m_ScoopType] = Mathf.Max(0, m_ScoopAmmoCounts[m_ScoopType] - 1);
+
+        var ammoChangedEventArgs = new ScoopAmmoChangedEventArgs (m_ScoopType, m_ScoopAmmoCounts[m_ScoopType], MaxScoopAmount);
+        this.OnRaiseScoopAmmoChangedEvent(ammoChangedEventArgs);
+    }
+    
+    protected virtual void OnRaiseScoopAmmoChangedEvent(ScoopAmmoChangedEventArgs e)
+    {
+        EventHandler<ScoopAmmoChangedEventArgs> raiseEvent = OnScoopAmmoChangedEvent;
+        if (raiseEvent != null)
+        {
+            raiseEvent(this, e);
+        }
     }
 }

--- a/Assets/Imports/FPS/Scripts/Game/Shared/IceCreamScoop.cs
+++ b/Assets/Imports/FPS/Scripts/Game/Shared/IceCreamScoop.cs
@@ -5,9 +5,9 @@ using UnityEngine;
 public enum FlavorType
 {
     CHOCOLATE,
-    MINT,
+    VANILLA,
     BERRY,
-    VANILLA
+    MINT,
 }
 
 public class IceCreamScoop : MonoBehaviour

--- a/Assets/Imports/FPS/Scripts/Game/Shared/IceCreamScoopController.cs
+++ b/Assets/Imports/FPS/Scripts/Game/Shared/IceCreamScoopController.cs
@@ -115,11 +115,11 @@ public class IceCreamScoopController : MonoBehaviour
         m_LastTimeShot = Time.time;
     }
 
-    public bool HandleShootInputs(bool inputDown, ProjectileBase currentScoop)
+    public bool HandleShootInputs(bool inputDown, IceCreamInventoryManager scoopInventory)
     {
         if (inputDown)
         {
-            return TryShoot(currentScoop);
+            return TryShoot(scoopInventory);
         }
         
         return false;
@@ -131,15 +131,17 @@ public class IceCreamScoopController : MonoBehaviour
         return spreadWorldDirection;
     }
 
-    bool TryShoot(ProjectileBase currentScoop)
+    bool TryShoot(IceCreamInventoryManager scoopInventory)
     {
-        if (m_CurrentAmmo >= 1f && m_LastTimeShot + DelayBetweenShots < Time.time)
+        if (m_LastTimeShot + DelayBetweenShots < Time.time)
         {
-            
-            HandleShoot(currentScoop);
-            m_CurrentAmmo -= 1f;
-
-            return true;
+            if (scoopInventory.CurrentAmmo > 0)
+            {
+                var currentScoop = scoopInventory.GetCurrentScoopType();
+                HandleShoot(currentScoop);
+                // m_CurrentAmmo -= 1f;
+                return true;
+            }
         }
 
         return false;

--- a/Assets/Imports/FPS/Scripts/Gameplay/Managers/PlayerScoopManager.cs
+++ b/Assets/Imports/FPS/Scripts/Gameplay/Managers/PlayerScoopManager.cs
@@ -78,6 +78,8 @@ public class PlayerScoopManager : MonoBehaviour
         
         m_ScoopInventoryManager = GetComponent<IceCreamInventoryManager>();
 
+        m_ScoopInventoryManager.OnScoopAmmoChangedEvent += PrintOutAmmo;
+
         SetFov(DefaultFov);
         InitalizeScoop();
     }
@@ -90,7 +92,7 @@ public class PlayerScoopManager : MonoBehaviour
 
             // handle shooting
             bool hasFired = scoopController.HandleShootInputs(
-                m_InputHandler.GetFireInputDown(), m_ScoopInventoryManager.GetCurrentScoopType());
+                m_InputHandler.GetFireInputDown(), m_ScoopInventoryManager);
 
         }
 
@@ -211,5 +213,12 @@ public class PlayerScoopManager : MonoBehaviour
         {
             t.gameObject.layer = layerIndex;
         }
+
+        scoopController.OnShoot += m_ScoopInventoryManager.UpdateAmmo;
+    }
+
+    void PrintOutAmmo(object sender, ScoopAmmoChangedEventArgs e)
+    {
+        Debug.Log("Scoop Type: " + e.AmmoType + " now has ammo count: " + e.CurrentAmmoCount + " out of " + e.MaxAmmoCount);
     }
 }

--- a/Assets/Scenes/TestScenes/PrototypeScene.unity
+++ b/Assets/Scenes/TestScenes/PrototypeScene.unity
@@ -1832,6 +1832,11 @@ PrefabInstance:
       propertyPath: m_TagString
       value: ChaseZone
       objectReference: {fileID: 0}
+    - target: {fileID: 1287918292983209691, guid: b002d47e5cbde4f24a28d91335273740,
+        type: 3}
+      propertyPath: m_ScoopNeeded
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6987078180625565360, guid: b002d47e5cbde4f24a28d91335273740,
         type: 3}
       propertyPath: m_RootOrder


### PR DESCRIPTION
This PR addes the ability to change scoop type by pressing the different number keys:
1 - Chocolate
2- Vanilla
3- Berry
4 - Mint


This also adds an event that triggers whenever the ammo count changes. This can be subscribed to display the appropriate ammo values on the UI