### PR TITLE
Donovan/bug fix on restart game

### DIFF
--- a/Assets/Imports/FPS/Scripts/UI/LoadSceneButton.cs
+++ b/Assets/Imports/FPS/Scripts/UI/LoadSceneButton.cs
@@ -14,12 +14,14 @@ namespace Unity.FPS.UI
             if (EventSystem.current.currentSelectedGameObject == gameObject
                 && Input.GetButtonDown(GameConstants.k_ButtonNameSubmit))
             {
+                Debug.Log("transition button pressed");
                 LoadTargetScene();
             }
         }
 
         public void LoadTargetScene()
         {
+            Debug.Log("transition in load scene button triggered");
             SceneManager.LoadScene(SceneName);
         }
     }

--- a/Assets/Imports/FPS/Scripts/UI/LoadSceneButton.cs
+++ b/Assets/Imports/FPS/Scripts/UI/LoadSceneButton.cs
@@ -14,14 +14,12 @@ namespace Unity.FPS.UI
             if (EventSystem.current.currentSelectedGameObject == gameObject
                 && Input.GetButtonDown(GameConstants.k_ButtonNameSubmit))
             {
-                Debug.Log("transition button pressed");
                 LoadTargetScene();
             }
         }
 
         public void LoadTargetScene()
         {
-            Debug.Log("transition in load scene button triggered");
             SceneManager.LoadScene(SceneName);
         }
     }

--- a/Assets/Imports/ModAssets/Models/Basic/IceCreamScoopBasic.prefab
+++ b/Assets/Imports/ModAssets/Models/Basic/IceCreamScoopBasic.prefab
@@ -12,7 +12,6 @@ GameObject:
   - component: {fileID: 5114838895850710326}
   - component: {fileID: 5646916673719110250}
   - component: {fileID: 6328702810459766709}
-  - component: {fileID: -3200367404912710480}
   m_Layer: 0
   m_Name: IceCreamScoopBasic
   m_TagString: Untagged
@@ -96,21 +95,3 @@ SphereCollider:
   serializedVersion: 2
   m_Radius: 0.5
   m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &-3200367404912710480
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7796278100810727425}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 74a30e9f2d5f18848a93edd39be2d726, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  icymaterial: {fileID: 2100000, guid: a6ce0cb30d59a6b489a83e9ffe838c2a, type: 2}
-  icymaterialsList:
-  - {fileID: 2100000, guid: a6ce0cb30d59a6b489a83e9ffe838c2a, type: 2}
-  - {fileID: 2100000, guid: e7a35a5344717e443896ffc33de5e6cc, type: 2}
-  - {fileID: 2100000, guid: da7fa5a7c0bffbb4cb42a032e79f05e5, type: 2}
-  - {fileID: 2100000, guid: add9685a84d2a8e40856a14fb7a9bb4b, type: 2}

--- a/Assets/Scripts/UI/LoadSceneManager.cs
+++ b/Assets/Scripts/UI/LoadSceneManager.cs
@@ -21,14 +21,13 @@ public class LoadSceneManager : MonoBehaviour
 
     public void MoveToScene()
     {
-        Debug.Log("transition 1");
+        Time.timeScale = 1f; // need to set timescale back to one in the case users quit game from the pause screen
         SceneManager.LoadScene(SceneName);
     }
 
     //Added for a quick way to transition scenes on win
     public void MoveToScene(string SceneName)
     {
-        Debug.Log("transition 1");
         SceneManager.LoadScene(SceneName);
     }
 

--- a/Assets/Scripts/UI/LoadSceneManager.cs
+++ b/Assets/Scripts/UI/LoadSceneManager.cs
@@ -21,12 +21,14 @@ public class LoadSceneManager : MonoBehaviour
 
     public void MoveToScene()
     {
+        Debug.Log("transition 1");
         SceneManager.LoadScene(SceneName);
     }
 
     //Added for a quick way to transition scenes on win
     public void MoveToScene(string SceneName)
     {
+        Debug.Log("transition 1");
         SceneManager.LoadScene(SceneName);
     }
 


### PR DESCRIPTION
Fixed two bugs:
1. The issue on game restart specifically from this path was fixed by setting the time scale back to 1 whenever a scene is loaded to assure it is set to one when the game is started up again:
Start game -> pause > quit game -> main menu -> play game

2. IceCreamScoopBasic prefab had an old script throwing warnings so I removed it and retested. Not sure what script it was but no errors or warnings thrown after removing it (the script was never present in the refactor version so not sure what it is or where it came from).
