### PR TITLE
added a cursor confine statement to player input handler after testing

### DIFF
--- a/Assets/Imports/FPS/Scripts/Game/Shared/PlayerInputHandler.cs
+++ b/Assets/Imports/FPS/Scripts/Game/Shared/PlayerInputHandler.cs
@@ -32,6 +32,7 @@ public class PlayerInputHandler : MonoBehaviour
         DebugUtility.HandleErrorIfNullFindObject<GameFlowManager, PlayerInputHandler>(m_GameFlowManager, this);
 
         Cursor.lockState = CursorLockMode.Locked;
+        Cursor.lockState = CursorLockMode.Confined;
         Cursor.visible = false;
     }
 


### PR DESCRIPTION
Tested multiple instances. Found that adding the confine cursor statement to the player input handler would confine to the cursor to the game window once the game window comes in focus (user clicks the game window).